### PR TITLE
fix(mssql): report real rows_affected for parameterized DML

### DIFF
--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -104,7 +104,20 @@ jobs:
           --no-default-features
           --features mssql,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }},macros,migrate
 
-      - run: docker compose -f tests/docker-compose.yml run -d -p 1433:1433 --name mssql_${{ matrix.mssql }} mssql_${{ matrix.mssql }}
+      # Retry: the SQL Server base image pull from mcr.microsoft.com can return a
+      # transient 403 when many matrix jobs pull it concurrently.
+      - name: Start SQL Server
+        run: |
+          for i in 1 2 3; do
+            docker rm -f mssql_${{ matrix.mssql }} 2>/dev/null || true
+            if docker compose -f tests/docker-compose.yml run -d -p 1433:1433 --name mssql_${{ matrix.mssql }} mssql_${{ matrix.mssql }}; then
+              exit 0
+            fi
+            echo "::warning::SQL Server start attempt $i failed (transient registry error?); retrying in 20s"
+            sleep 20
+          done
+          echo "::error::Failed to start SQL Server after 3 attempts"
+          exit 1
       - run: sleep 60
 
       # Create data dir for offline mode

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -1,0 +1,152 @@
+name: MSSQL CI
+
+# Dedicated CI for this MSSQL-focused fork of SQLx.
+# It mirrors the MSSQL-relevant parts of `sqlx.yml` but scoped to MSSQL features
+# only, so the status of the MSSQL driver changes is easy to see at a glance.
+# The upstream `sqlx.yml` / `sqlx-cli.yml` / `examples.yml` workflows are left
+# untouched.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "*-dev"
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - run: rustup component add rustfmt
+      - run: cargo fmt --all -- --check
+
+  check:
+    name: Check (MSSQL)
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runtime: [ tokio ]
+        tls: [ native-tls, rustls, none ]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      # Swatinem/rust-cache recommends setting up the rust toolchain first
+      # because it's used in the cache keys.
+      - name: Setup Rust
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: >
+          cargo clippy
+          --no-default-features
+          --features mssql,any,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }},macros,migrate
+          -- -D warnings
+
+  test:
+    name: Unit Tests (MSSQL)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test sqlx-core
+        run: cargo test -p sqlx-core --all-features
+
+      - name: Test sqlx-mssql
+        run: cargo test -p sqlx-mssql --all-features
+
+      # Note: use `--lib` to not run integration tests that require a DB.
+      - name: Test sqlx (lib only)
+        run: >
+          cargo test
+          -p sqlx
+          --lib
+          --no-default-features
+          --features mssql,any,_unstable-all-types,macros,migrate,runtime-tokio,tls-rustls
+
+  mssql:
+    name: MSSQL
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        mssql: [ 2022, 2019 ]
+        runtime: [ tokio ]
+        tls: [ rustls-ring, none ]
+    needs: check
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: >
+          cargo build
+          --no-default-features
+          --features mssql,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }},macros,migrate
+
+      - run: docker compose -f tests/docker-compose.yml run -d -p 1433:1433 --name mssql_${{ matrix.mssql }} mssql_${{ matrix.mssql }}
+      - run: sleep 60
+
+      # Create data dir for offline mode
+      - run: mkdir .sqlx
+
+      - run: >
+          cargo test
+          --no-default-features
+          --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
+        env:
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          SQLX_OFFLINE_DIR: .sqlx
+          RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}
+
+      # Run the `test-attr` test again to cover cleanup.
+      - run: >
+          cargo test
+          --test mssql-test-attr
+          --no-default-features
+          --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
+        env:
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          SQLX_OFFLINE_DIR: .sqlx
+          RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}
+
+      # Remove test artifacts
+      - run: cargo clean -p sqlx
+
+      # Build the macros-test in offline mode (omit DATABASE_URL)
+      - run: >
+          cargo build
+          --no-default-features
+          --test mssql-macros
+          --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
+        env:
+          SQLX_OFFLINE: true
+          SQLX_OFFLINE_DIR: .sqlx
+          RUSTFLAGS: -D warnings --cfg mssql_${{ matrix.mssql }}
+
+      # Test macros in offline mode (still needs DATABASE_URL to run)
+      - run: >
+          cargo test
+          --no-default-features
+          --test mssql-macros
+          --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
+        env:
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          SQLX_OFFLINE: true
+          SQLX_OFFLINE_DIR: .sqlx
+          RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -56,6 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # `sqlx-mssql --all-features` enables tiberius `integrated-auth-gssapi`,
+      # which builds `libgssapi-sys` and needs the Kerberos dev headers.
+      - name: Install Kerberos headers (for tiberius integrated-auth-gssapi)
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
+
       - name: Setup Rust
         run: rustup show active-toolchain || rustup toolchain install
 

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -115,7 +115,7 @@ jobs:
           --no-default-features
           --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
-          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx?sslmode=disabled
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}
 
@@ -126,7 +126,7 @@ jobs:
           --no-default-features
           --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
-          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx?sslmode=disabled
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}
 
@@ -151,7 +151,7 @@ jobs:
           --test mssql-macros
           --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
-          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx?sslmode=disabled
           SQLX_OFFLINE: true
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -762,7 +762,7 @@ jobs:
           --no-default-features
           --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
-          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx?sslmode=disabled
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}
 
@@ -773,7 +773,7 @@ jobs:
           --no-default-features
           --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
-          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx?sslmode=disabled
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}
 
@@ -798,7 +798,7 @@ jobs:
           --test mssql-macros
           --features any,mssql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
-          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx
+          DATABASE_URL: mssql://sa:YourStrong!Passw0rd@localhost:1433/sqlx?sslmode=disabled
           SQLX_OFFLINE: true
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: --cfg mssql_${{ matrix.mssql }}

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -751,7 +751,20 @@ jobs:
           --no-default-features
           --features mssql,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }},macros,migrate
 
-      - run: docker compose -f tests/docker-compose.yml run -d -p 1433:1433 --name mssql_${{ matrix.mssql }} mssql_${{ matrix.mssql }}
+      # Retry: the SQL Server base image pull from mcr.microsoft.com can return a
+      # transient 403 when many matrix jobs pull it concurrently.
+      - name: Start SQL Server
+        run: |
+          for i in 1 2 3; do
+            docker rm -f mssql_${{ matrix.mssql }} 2>/dev/null || true
+            if docker compose -f tests/docker-compose.yml run -d -p 1433:1433 --name mssql_${{ matrix.mssql }} mssql_${{ matrix.mssql }}; then
+              exit 0
+            fi
+            echo "::warning::SQL Server start attempt $i failed (transient registry error?); retrying in 20s"
+            sleep 20
+          done
+          echo "::error::Failed to start SQL Server after 3 attempts"
+          exit 1
       - run: sleep 60
 
       # Create data dir for offline mode

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -87,6 +87,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # `sqlx-mssql --all-features` enables tiberius `integrated-auth-gssapi`,
+      # which builds `libgssapi-sys` and needs the Kerberos dev headers.
+      - name: Install Kerberos headers (for tiberius integrated-auth-gssapi)
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
+
       # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
       - name: Setup Rust
         run: rustup show active-toolchain || rustup toolchain install

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
   <!-- Github Actions -->
   <a href="https://github.com/launchbadge/sqlx/actions/workflows/sqlx.yml?query=branch%3Amain">
     <img src="https://img.shields.io/github/actions/workflow/status/launchbadge/sqlx/sqlx.yml?branch=main&style=flat-square" alt="actions status" /></a>
+  <!-- MSSQL fork CI (this fork) -->
+  <a href="https://github.com/pabl-o-ce/sqlx/actions/workflows/mssql.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/pabl-o-ce/sqlx/mssql.yml?branch=main&style=flat-square&label=mssql%20ci" alt="MSSQL CI status" /></a>
   <!-- Version -->
   <a href="https://crates.io/crates/sqlx">
     <img src="https://img.shields.io/crates/v/sqlx.svg?style=flat-square"
@@ -26,6 +29,14 @@
     <img src="https://img.shields.io/crates/d/sqlx.svg?style=flat-square" alt="Download" />
   </a>
 </div>
+
+<br />
+
+> **Fork note:** This is an **MSSQL (SQL Server)-focused fork** of SQLx. The
+> **`mssql ci`** badge above tracks the dedicated
+> [`MSSQL CI`](.github/workflows/mssql.yml) workflow — watch it to know whether
+> the MSSQL driver changes are passing. The upstream multi-database workflows
+> are left as-is.
 
 <div align="center">
   <h4>

--- a/benches/sqlite/describe.rs
+++ b/benches/sqlite/describe.rs
@@ -1,14 +1,21 @@
+// This single-threaded benchmark deliberately holds a `RefCell` borrow across
+// `.await` (the connection is shared only within one task).
+#![allow(clippy::await_holding_refcell_ref)]
+
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
 
 use sqlx::sqlite::{Sqlite, SqliteConnection};
-use sqlx::Executor;
+use sqlx::{Executor, SqlSafeStr};
 use sqlx_test::new;
 
 // Here we have an async function to benchmark
 async fn do_describe_trivial(db: &std::cell::RefCell<SqliteConnection>) {
-    db.borrow_mut().describe("select 1").await.unwrap();
+    db.borrow_mut()
+        .describe("select 1".into_sql_str())
+        .await
+        .unwrap();
 }
 
 async fn do_describe_recursive(db: &std::cell::RefCell<SqliteConnection>) {
@@ -27,7 +34,8 @@ async fn do_describe_recursive(db: &std::cell::RefCell<SqliteConnection>) {
             begin_date
             FROM schedule
             GROUP BY begin_date
-            "#,
+            "#
+            .into_sql_str(),
         )
         .await
         .unwrap();
@@ -35,14 +43,14 @@ async fn do_describe_recursive(db: &std::cell::RefCell<SqliteConnection>) {
 
 async fn do_describe_insert(db: &std::cell::RefCell<SqliteConnection>) {
     db.borrow_mut()
-        .describe("INSERT INTO tweet (id, text) VALUES (2, 'Hello') RETURNING *")
+        .describe("INSERT INTO tweet (id, text) VALUES (2, 'Hello') RETURNING *".into_sql_str())
         .await
         .unwrap();
 }
 
 async fn do_describe_insert_fks(db: &std::cell::RefCell<SqliteConnection>) {
     db.borrow_mut()
-        .describe("insert into statements (text) values ('a') returning id")
+        .describe("insert into statements (text) values ('a') returning id".into_sql_str())
         .await
         .unwrap();
 }

--- a/examples/mssql/todos/Cargo.toml
+++ b/examples/mssql/todos/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 workspace = "../../../"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.58"
 sqlx = { path = "../../../", features = [ "mssql", "runtime-tokio", "tls-native-tls" ] }
-clap = { version = "4", features = ["derive"] }
-tokio = { version = "1.20.0", features = ["rt", "macros"] }
-dotenvy = "0.15.0"
+clap = { version = "4.4.7", features = ["derive"] }
+tokio = { version = "1.25.0", features = ["rt", "macros"] }
+dotenvy = "0.15.7"

--- a/sqlx-mssql/Cargo.toml
+++ b/sqlx-mssql/Cargo.toml
@@ -30,12 +30,12 @@ uuid = ["dep:uuid", "sqlx-core/uuid"]
 sqlx-core = { workspace = true }
 
 # TDS protocol driver
-tiberius = { version = "0.12", default-features = false, features = ["tds73"] }
+tiberius = { version = "0.12.3", default-features = false, features = ["tds73"] }
 
 # Futures crates
-futures-core = { version = "0.3.19", default-features = false }
-futures-io = "0.3.24"
-futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "sink", "io"] }
+futures-core = { version = "0.3.32", default-features = false }
+futures-io = "0.3.32"
+futures-util = { version = "0.3.32", default-features = false, features = ["alloc", "sink", "io"] }
 
 # Runtime bridging
 tokio = { workspace = true, optional = true }
@@ -50,16 +50,16 @@ time = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 
 # Misc
-bytes = "1.1.0"
+bytes = "1.2.0"
 either = "1.6.1"
 log = "0.4.18"
 tracing = { version = "0.1.37", features = ["log"] }
-percent-encoding = "2.1.0"
+percent-encoding = "2.3.0"
 
 dotenvy.workspace = true
 thiserror.workspace = true
 
-serde = { version = "1.0.144", optional = true }
+serde = { version = "1.0.219", optional = true }
 
 [dev-dependencies]
 # FIXME: https://github.com/rust-lang/cargo/issues/15622

--- a/sqlx-mssql/src/advisory_lock.rs
+++ b/sqlx-mssql/src/advisory_lock.rs
@@ -196,8 +196,16 @@ impl MssqlAdvisoryLock {
     /// Returns `Ok(true)` if the lock was successfully released, `Ok(false)`
     /// if the lock was not held by this session.
     pub async fn release(&self, conn: &mut MssqlConnection) -> Result<bool, Error> {
+        // `sp_releaseapplock` *raises* error 1223 (rather than returning a
+        // status) when the lock isn't held by this session; catch it and map it
+        // to the -999 sentinel so a not-held release reports `Ok(false)`.
         let sql = "DECLARE @r INT; \
-                   EXEC @r = sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'; \
+                   BEGIN TRY \
+                       EXEC @r = sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'; \
+                   END TRY \
+                   BEGIN CATCH \
+                       IF ERROR_NUMBER() = 1223 SET @r = -999; ELSE THROW; \
+                   END CATCH; \
                    SELECT @r;";
 
         let status: i32 = query_scalar(sql)

--- a/sqlx-mssql/src/arguments.rs
+++ b/sqlx-mssql/src/arguments.rs
@@ -18,16 +18,15 @@ impl MssqlArguments {
     where
         T: Encode<'q, Mssql> + Type<Mssql>,
     {
+        let len_before = self.values.len();
         let is_null = value.encode(&mut self.values)?;
-        if is_null.is_null() {
-            // If the encoder signaled null but didn't push a value, push a Null
-            if self
-                .values
-                .last()
-                .is_none_or(|v| !matches!(v, MssqlArgumentValue::Null))
-            {
-                self.values.push(MssqlArgumentValue::Null);
-            }
+        // If the encoder signaled null but didn't push a value, push a Null
+        // placeholder. Compare against the pre-encode length rather than the
+        // last element: checking the last element wrongly suppressed a NULL when
+        // the *previous* argument was also NULL, leaving that parameter
+        // undeclared (e.g. binding two `None`s -> "must declare @p2").
+        if is_null.is_null() && self.values.len() == len_before {
+            self.values.push(MssqlArgumentValue::Null);
         }
         Ok(())
     }

--- a/sqlx-mssql/src/connection/executor.rs
+++ b/sqlx-mssql/src/connection/executor.rs
@@ -134,182 +134,7 @@ impl MssqlConnection {
         if let Some(args) = arguments {
             // Parameterized query using tiberius::Query
             let mut query = tiberius::Query::new(sql);
-
-            for arg in &args.values {
-                match arg {
-                    MssqlArgumentValue::Null => {
-                        query.bind(Option::<&str>::None);
-                    }
-                    MssqlArgumentValue::Bool(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::U8(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::I16(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::I32(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::I64(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::F32(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::F64(v) => {
-                        query.bind(*v);
-                    }
-                    MssqlArgumentValue::String(v) => {
-                        query.bind(v.as_str());
-                    }
-                    MssqlArgumentValue::Binary(v) => {
-                        query.bind(v.as_slice());
-                    }
-                    #[cfg(feature = "chrono")]
-                    MssqlArgumentValue::NaiveDateTime(v) => {
-                        query.bind(*v);
-                    }
-                    #[cfg(feature = "chrono")]
-                    MssqlArgumentValue::NaiveDate(v) => {
-                        query.bind(*v);
-                    }
-                    #[cfg(feature = "chrono")]
-                    MssqlArgumentValue::NaiveTime(v) => {
-                        query.bind(*v);
-                    }
-                    #[cfg(feature = "chrono")]
-                    MssqlArgumentValue::DateTimeFixedOffset(v) => {
-                        use chrono::Timelike as _;
-                        let epoch = chrono::NaiveDate::from_ymd_opt(1, 1, 1)
-                            .expect("epoch 0001-01-01 is always valid");
-                        let naive = v.naive_local();
-                        let days = days_since_epoch_to_u32((naive.date() - epoch).num_days())?;
-                        let time = naive.time();
-                        let total_ns = u64::from(time.num_seconds_from_midnight()) * 1_000_000_000
-                            + (u64::from(time.nanosecond()) % 1_000_000_000);
-                        let increments = total_ns / 100;
-                        let offset_minutes = v.offset().local_minus_utc() / 60;
-                        let dt2 = tiberius::time::DateTime2::new(
-                            tiberius::time::Date::new(days),
-                            tiberius::time::Time::new(increments, 7),
-                        );
-                        let cd = tiberius::ColumnData::DateTimeOffset(Some(
-                            tiberius::time::DateTimeOffset::new(
-                                dt2,
-                                offset_minutes_to_i16(offset_minutes)?,
-                            ),
-                        ));
-                        query.bind(ColumnDataWrapper(cd));
-                    }
-                    #[cfg(feature = "uuid")]
-                    MssqlArgumentValue::Uuid(v) => {
-                        query.bind(v);
-                    }
-                    #[cfg(feature = "rust_decimal")]
-                    MssqlArgumentValue::Decimal(v) => {
-                        let unpacked = v.unpack();
-                        // SAFETY: rust_decimal mantissa is ≤96 bits (hi:mid:lo are u32s), fits in i128.
-                        #[allow(clippy::cast_possible_wrap)]
-                        let mut value = (((unpacked.hi as u128) << 64)
-                            + ((unpacked.mid as u128) << 32)
-                            + unpacked.lo as u128) as i128;
-                        if v.is_sign_negative() {
-                            value = -value;
-                        }
-                        let scale = v.scale();
-                        if scale > 37 {
-                            return Err(Error::Encode(
-                                format!(
-                                    "rust_decimal scale {scale} exceeds SQL Server maximum of 37"
-                                )
-                                .into(),
-                            ));
-                        }
-                        // SAFETY: guarded by `scale > 37` check above; 0..=37 fits in u8.
-                        #[allow(clippy::cast_possible_truncation)]
-                        let scale_u8 = scale as u8;
-                        query.bind(tiberius::numeric::Numeric::new_with_scale(value, scale_u8));
-                    }
-                    #[cfg(feature = "time")]
-                    MssqlArgumentValue::TimeDate(v) => {
-                        let epoch = time::Date::from_ordinal_date(1, 1)
-                            .expect("epoch 0001-01-01 is always valid");
-                        let days = days_since_epoch_to_u32((*v - epoch).whole_days())?;
-                        let cd = tiberius::ColumnData::Date(Some(tiberius::time::Date::new(days)));
-                        query.bind(ColumnDataWrapper(cd));
-                    }
-                    #[cfg(feature = "time")]
-                    MssqlArgumentValue::TimeTime(v) => {
-                        let (h, m, s, ns) = v.as_hms_nano();
-                        let total_ns = u64::from(h) * 3_600_000_000_000
-                            + u64::from(m) * 60_000_000_000
-                            + u64::from(s) * 1_000_000_000
-                            + u64::from(ns);
-                        // Scale 7 = 100ns increments
-                        let increments = total_ns / 100;
-                        let cd = tiberius::ColumnData::Time(Some(tiberius::time::Time::new(
-                            increments, 7,
-                        )));
-                        query.bind(ColumnDataWrapper(cd));
-                    }
-                    #[cfg(feature = "time")]
-                    MssqlArgumentValue::TimePrimitiveDateTime(v) => {
-                        let date = v.date();
-                        let time = v.time();
-                        let epoch = time::Date::from_ordinal_date(1, 1)
-                            .expect("epoch 0001-01-01 is always valid");
-                        let days = days_since_epoch_to_u32((date - epoch).whole_days())?;
-                        let (h, m, s, ns) = time.as_hms_nano();
-                        let total_ns = u64::from(h) * 3_600_000_000_000
-                            + u64::from(m) * 60_000_000_000
-                            + u64::from(s) * 1_000_000_000
-                            + u64::from(ns);
-                        let increments = total_ns / 100;
-                        let cd =
-                            tiberius::ColumnData::DateTime2(Some(tiberius::time::DateTime2::new(
-                                tiberius::time::Date::new(days),
-                                tiberius::time::Time::new(increments, 7),
-                            )));
-                        query.bind(ColumnDataWrapper(cd));
-                    }
-                    #[cfg(feature = "time")]
-                    MssqlArgumentValue::TimeOffsetDateTime(v) => {
-                        let epoch = time::Date::from_ordinal_date(1, 1)
-                            .expect("epoch 0001-01-01 is always valid");
-                        let offset_minutes = v.offset().whole_seconds() / 60;
-                        let date = v.date();
-                        let time = v.time();
-                        let days = days_since_epoch_to_u32((date - epoch).whole_days())?;
-                        let (h, m, s, ns) = time.as_hms_nano();
-                        let total_ns = u64::from(h) * 3_600_000_000_000
-                            + u64::from(m) * 60_000_000_000
-                            + u64::from(s) * 1_000_000_000
-                            + u64::from(ns);
-                        let increments = total_ns / 100;
-                        let dt2 = tiberius::time::DateTime2::new(
-                            tiberius::time::Date::new(days),
-                            tiberius::time::Time::new(increments, 7),
-                        );
-                        let cd = tiberius::ColumnData::DateTimeOffset(Some(
-                            tiberius::time::DateTimeOffset::new(
-                                dt2,
-                                offset_minutes_to_i16(offset_minutes)?,
-                            ),
-                        ));
-                        query.bind(ColumnDataWrapper(cd));
-                    }
-                    #[cfg(feature = "bigdecimal")]
-                    MssqlArgumentValue::BigDecimal(v) => {
-                        let (value, scale) = bigdecimal_to_numeric(v)?;
-                        let cd = tiberius::ColumnData::Numeric(Some(
-                            tiberius::numeric::Numeric::new_with_scale(value, scale),
-                        ));
-                        query.bind(ColumnDataWrapper(cd));
-                    }
-                }
-            }
+            bind_arguments(&mut query, &args)?;
 
             let stream = query
                 .query(&mut self.inner.client)
@@ -329,6 +154,230 @@ impl MssqlConnection {
 
         Ok(results)
     }
+
+    /// Execute a parameterized statement and return the affected-row count(s)
+    /// reported by SQL Server.
+    ///
+    /// Unlike [`run`], which uses tiberius `query()` (a `QueryStream` that
+    /// silently drops the `DONE`/`DONEINPROC` tokens carrying the affected-row
+    /// count), this drives tiberius `execute()`, whose `ExecuteResult` reads
+    /// those tokens. This is why `rows_affected()` is accurate for
+    /// `INSERT`/`UPDATE`/`DELETE` here but not via the fetch path.
+    ///
+    /// One [`MssqlQueryResult`] is returned per statement in the batch, matching
+    /// `execute_many`'s one-result-per-statement contract.
+    ///
+    /// This path is parameterized only: it goes through `sp_executesql`, so it
+    /// must not be used for DDL such as `CREATE PROCEDURE`/`VIEW`/`TRIGGER` that
+    /// must be the first statement in a plain batch — those stay on the
+    /// no-parameter [`run`] (`simple_query`) path.
+    pub(crate) async fn run_execute(
+        &mut self,
+        sql: &str,
+        arguments: MssqlArguments,
+    ) -> Result<Vec<MssqlQueryResult>, Error> {
+        // Resolve any pending rollback first
+        crate::transaction::resolve_pending_rollback(self).await?;
+
+        let mut logger = QueryLogger::new(
+            AssertSqlSafe(sql).into_sql_str(),
+            self.inner.log_settings.clone(),
+        );
+
+        let mut query = tiberius::Query::new(sql);
+        bind_arguments(&mut query, &arguments)?;
+
+        let result = query
+            .execute(&mut self.inner.client)
+            .await
+            .map_err(tiberius_err)?;
+
+        Ok(result
+            .rows_affected()
+            .iter()
+            .map(|&rows_affected| {
+                logger.increase_rows_affected(rows_affected);
+                MssqlQueryResult { rows_affected }
+            })
+            .collect())
+    }
+}
+
+/// Bind a query's arguments onto a `tiberius::Query`.
+///
+/// Shared by [`MssqlConnection::run`] (fetch path) and
+/// [`MssqlConnection::run_execute`] (execute path). The `'a` lifetime ties
+/// borrowed argument data (e.g. `String`/`Vec<u8>`) to `args`.
+fn bind_arguments<'a>(
+    query: &mut tiberius::Query<'a>,
+    args: &'a MssqlArguments,
+) -> Result<(), Error> {
+    for arg in &args.values {
+        match arg {
+            MssqlArgumentValue::Null => {
+                query.bind(Option::<&str>::None);
+            }
+            MssqlArgumentValue::Bool(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::U8(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::I16(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::I32(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::I64(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::F32(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::F64(v) => {
+                query.bind(*v);
+            }
+            MssqlArgumentValue::String(v) => {
+                query.bind(v.as_str());
+            }
+            MssqlArgumentValue::Binary(v) => {
+                query.bind(v.as_slice());
+            }
+            #[cfg(feature = "chrono")]
+            MssqlArgumentValue::NaiveDateTime(v) => {
+                query.bind(*v);
+            }
+            #[cfg(feature = "chrono")]
+            MssqlArgumentValue::NaiveDate(v) => {
+                query.bind(*v);
+            }
+            #[cfg(feature = "chrono")]
+            MssqlArgumentValue::NaiveTime(v) => {
+                query.bind(*v);
+            }
+            #[cfg(feature = "chrono")]
+            MssqlArgumentValue::DateTimeFixedOffset(v) => {
+                use chrono::Timelike as _;
+                let epoch = chrono::NaiveDate::from_ymd_opt(1, 1, 1)
+                    .expect("epoch 0001-01-01 is always valid");
+                let naive = v.naive_local();
+                let days = days_since_epoch_to_u32((naive.date() - epoch).num_days())?;
+                let time = naive.time();
+                let total_ns = u64::from(time.num_seconds_from_midnight()) * 1_000_000_000
+                    + (u64::from(time.nanosecond()) % 1_000_000_000);
+                let increments = total_ns / 100;
+                let offset_minutes = v.offset().local_minus_utc() / 60;
+                let dt2 = tiberius::time::DateTime2::new(
+                    tiberius::time::Date::new(days),
+                    tiberius::time::Time::new(increments, 7),
+                );
+                let cd = tiberius::ColumnData::DateTimeOffset(Some(
+                    tiberius::time::DateTimeOffset::new(dt2, offset_minutes_to_i16(offset_minutes)?),
+                ));
+                query.bind(ColumnDataWrapper(cd));
+            }
+            #[cfg(feature = "uuid")]
+            MssqlArgumentValue::Uuid(v) => {
+                query.bind(v);
+            }
+            #[cfg(feature = "rust_decimal")]
+            MssqlArgumentValue::Decimal(v) => {
+                let unpacked = v.unpack();
+                // SAFETY: rust_decimal mantissa is ≤96 bits (hi:mid:lo are u32s), fits in i128.
+                #[allow(clippy::cast_possible_wrap)]
+                let mut value = (((unpacked.hi as u128) << 64)
+                    + ((unpacked.mid as u128) << 32)
+                    + unpacked.lo as u128) as i128;
+                if v.is_sign_negative() {
+                    value = -value;
+                }
+                let scale = v.scale();
+                if scale > 37 {
+                    return Err(Error::Encode(
+                        format!("rust_decimal scale {scale} exceeds SQL Server maximum of 37")
+                            .into(),
+                    ));
+                }
+                // SAFETY: guarded by `scale > 37` check above; 0..=37 fits in u8.
+                #[allow(clippy::cast_possible_truncation)]
+                let scale_u8 = scale as u8;
+                query.bind(tiberius::numeric::Numeric::new_with_scale(value, scale_u8));
+            }
+            #[cfg(feature = "time")]
+            MssqlArgumentValue::TimeDate(v) => {
+                let epoch = time::Date::from_ordinal_date(1, 1)
+                    .expect("epoch 0001-01-01 is always valid");
+                let days = days_since_epoch_to_u32((*v - epoch).whole_days())?;
+                let cd = tiberius::ColumnData::Date(Some(tiberius::time::Date::new(days)));
+                query.bind(ColumnDataWrapper(cd));
+            }
+            #[cfg(feature = "time")]
+            MssqlArgumentValue::TimeTime(v) => {
+                let (h, m, s, ns) = v.as_hms_nano();
+                let total_ns = u64::from(h) * 3_600_000_000_000
+                    + u64::from(m) * 60_000_000_000
+                    + u64::from(s) * 1_000_000_000
+                    + u64::from(ns);
+                // Scale 7 = 100ns increments
+                let increments = total_ns / 100;
+                let cd = tiberius::ColumnData::Time(Some(tiberius::time::Time::new(increments, 7)));
+                query.bind(ColumnDataWrapper(cd));
+            }
+            #[cfg(feature = "time")]
+            MssqlArgumentValue::TimePrimitiveDateTime(v) => {
+                let date = v.date();
+                let time = v.time();
+                let epoch = time::Date::from_ordinal_date(1, 1)
+                    .expect("epoch 0001-01-01 is always valid");
+                let days = days_since_epoch_to_u32((date - epoch).whole_days())?;
+                let (h, m, s, ns) = time.as_hms_nano();
+                let total_ns = u64::from(h) * 3_600_000_000_000
+                    + u64::from(m) * 60_000_000_000
+                    + u64::from(s) * 1_000_000_000
+                    + u64::from(ns);
+                let increments = total_ns / 100;
+                let cd = tiberius::ColumnData::DateTime2(Some(tiberius::time::DateTime2::new(
+                    tiberius::time::Date::new(days),
+                    tiberius::time::Time::new(increments, 7),
+                )));
+                query.bind(ColumnDataWrapper(cd));
+            }
+            #[cfg(feature = "time")]
+            MssqlArgumentValue::TimeOffsetDateTime(v) => {
+                let epoch = time::Date::from_ordinal_date(1, 1)
+                    .expect("epoch 0001-01-01 is always valid");
+                let offset_minutes = v.offset().whole_seconds() / 60;
+                let date = v.date();
+                let time = v.time();
+                let days = days_since_epoch_to_u32((date - epoch).whole_days())?;
+                let (h, m, s, ns) = time.as_hms_nano();
+                let total_ns = u64::from(h) * 3_600_000_000_000
+                    + u64::from(m) * 60_000_000_000
+                    + u64::from(s) * 1_000_000_000
+                    + u64::from(ns);
+                let increments = total_ns / 100;
+                let dt2 = tiberius::time::DateTime2::new(
+                    tiberius::time::Date::new(days),
+                    tiberius::time::Time::new(increments, 7),
+                );
+                let cd = tiberius::ColumnData::DateTimeOffset(Some(
+                    tiberius::time::DateTimeOffset::new(dt2, offset_minutes_to_i16(offset_minutes)?),
+                ));
+                query.bind(ColumnDataWrapper(cd));
+            }
+            #[cfg(feature = "bigdecimal")]
+            MssqlArgumentValue::BigDecimal(v) => {
+                let (value, scale) = bigdecimal_to_numeric(v)?;
+                let cd = tiberius::ColumnData::Numeric(Some(
+                    tiberius::numeric::Numeric::new_with_scale(value, scale),
+                ));
+                query.bind(ColumnDataWrapper(cd));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Collect all results from a tiberius QueryStream into a Vec.
@@ -480,6 +529,45 @@ impl<'c> Executor<'c> for &'c mut MssqlConnection {
                 Ok::<_, Error>(results)
             })
             .map_ok(|results| futures_util::stream::iter(results.into_iter().map(Ok)))
+            .try_flatten(),
+        )
+    }
+
+    fn execute_many<'e, 'q, E>(
+        self,
+        mut query: E,
+    ) -> BoxStream<'e, Result<MssqlQueryResult, Error>>
+    where
+        'c: 'e,
+        E: Execute<'q, Self::Database>,
+        'q: 'e,
+        E: 'q,
+    {
+        let arguments = query.take_arguments().map_err(Error::Encode);
+        let sql = query.sql();
+
+        Box::pin(
+            futures_util::stream::once(async move {
+                let results = match arguments? {
+                    // Parameterized statements go through tiberius `execute()`
+                    // (sp_executesql), whose `ExecuteResult` carries the real
+                    // affected-row count reported by SQL Server.
+                    Some(args) => self.run_execute(sql.as_str(), args).await?,
+                    // No-parameter statements stay on the plain-batch
+                    // `simple_query` path, which is required for DDL such as
+                    // `CREATE PROCEDURE`/`VIEW`/`TRIGGER` in migrations. That
+                    // path cannot read the affected-row count, so `rows_affected`
+                    // is best-effort there; bind your values and virtually all
+                    // real DML hits the accurate path above.
+                    None => self
+                        .run(sql.as_str(), None)
+                        .await?
+                        .into_iter()
+                        .filter_map(Either::left)
+                        .collect(),
+                };
+                Ok::<_, Error>(futures_util::stream::iter(results.into_iter().map(Ok)))
+            })
             .try_flatten(),
         )
     }

--- a/sqlx-mssql/src/connection/executor.rs
+++ b/sqlx-mssql/src/connection/executor.rs
@@ -261,7 +261,10 @@ fn bind_arguments<'a>(
                 use chrono::Timelike as _;
                 let epoch = chrono::NaiveDate::from_ymd_opt(1, 1, 1)
                     .expect("epoch 0001-01-01 is always valid");
-                let naive = v.naive_local();
+                // TDS DATETIMEOFFSET stores the datetime portion in UTC (with the
+                // offset kept separately), so encode the UTC instant, not the
+                // local wall-clock time.
+                let naive = v.naive_utc();
                 let days = days_since_epoch_to_u32((naive.date() - epoch).num_days())?;
                 let time = naive.time();
                 let total_ns = u64::from(time.num_seconds_from_midnight()) * 1_000_000_000

--- a/sqlx-mssql/src/connection/executor.rs
+++ b/sqlx-mssql/src/connection/executor.rs
@@ -273,7 +273,10 @@ fn bind_arguments<'a>(
                     tiberius::time::Time::new(increments, 7),
                 );
                 let cd = tiberius::ColumnData::DateTimeOffset(Some(
-                    tiberius::time::DateTimeOffset::new(dt2, offset_minutes_to_i16(offset_minutes)?),
+                    tiberius::time::DateTimeOffset::new(
+                        dt2,
+                        offset_minutes_to_i16(offset_minutes)?,
+                    ),
                 ));
                 query.bind(ColumnDataWrapper(cd));
             }
@@ -306,8 +309,8 @@ fn bind_arguments<'a>(
             }
             #[cfg(feature = "time")]
             MssqlArgumentValue::TimeDate(v) => {
-                let epoch = time::Date::from_ordinal_date(1, 1)
-                    .expect("epoch 0001-01-01 is always valid");
+                let epoch =
+                    time::Date::from_ordinal_date(1, 1).expect("epoch 0001-01-01 is always valid");
                 let days = days_since_epoch_to_u32((*v - epoch).whole_days())?;
                 let cd = tiberius::ColumnData::Date(Some(tiberius::time::Date::new(days)));
                 query.bind(ColumnDataWrapper(cd));
@@ -328,8 +331,8 @@ fn bind_arguments<'a>(
             MssqlArgumentValue::TimePrimitiveDateTime(v) => {
                 let date = v.date();
                 let time = v.time();
-                let epoch = time::Date::from_ordinal_date(1, 1)
-                    .expect("epoch 0001-01-01 is always valid");
+                let epoch =
+                    time::Date::from_ordinal_date(1, 1).expect("epoch 0001-01-01 is always valid");
                 let days = days_since_epoch_to_u32((date - epoch).whole_days())?;
                 let (h, m, s, ns) = time.as_hms_nano();
                 let total_ns = u64::from(h) * 3_600_000_000_000
@@ -345,8 +348,8 @@ fn bind_arguments<'a>(
             }
             #[cfg(feature = "time")]
             MssqlArgumentValue::TimeOffsetDateTime(v) => {
-                let epoch = time::Date::from_ordinal_date(1, 1)
-                    .expect("epoch 0001-01-01 is always valid");
+                let epoch =
+                    time::Date::from_ordinal_date(1, 1).expect("epoch 0001-01-01 is always valid");
                 let offset_minutes = v.offset().whole_seconds() / 60;
                 let date = v.date();
                 let time = v.time();
@@ -362,7 +365,10 @@ fn bind_arguments<'a>(
                     tiberius::time::Time::new(increments, 7),
                 );
                 let cd = tiberius::ColumnData::DateTimeOffset(Some(
-                    tiberius::time::DateTimeOffset::new(dt2, offset_minutes_to_i16(offset_minutes)?),
+                    tiberius::time::DateTimeOffset::new(
+                        dt2,
+                        offset_minutes_to_i16(offset_minutes)?,
+                    ),
                 ));
                 query.bind(ColumnDataWrapper(cd));
             }
@@ -533,10 +539,7 @@ impl<'c> Executor<'c> for &'c mut MssqlConnection {
         )
     }
 
-    fn execute_many<'e, 'q, E>(
-        self,
-        mut query: E,
-    ) -> BoxStream<'e, Result<MssqlQueryResult, Error>>
+    fn execute_many<'e, 'q, E>(self, mut query: E) -> BoxStream<'e, Result<MssqlQueryResult, Error>>
     where
         'c: 'e,
         E: Execute<'q, Self::Database>,

--- a/sqlx-mssql/src/connection/executor.rs
+++ b/sqlx-mssql/src/connection/executor.rs
@@ -473,7 +473,11 @@ fn build_columns_from_describe_rows(
     for (ordinal, row) in rows.iter().enumerate() {
         let name: &str = row.get("name").unwrap_or("");
         let type_name: &str = row.get("system_type_name").unwrap_or("UNKNOWN");
-        let type_info = MssqlTypeInfo::new(type_name.to_uppercase());
+        // `sp_describe_first_result_set` reports types with precision/length
+        // (e.g. "nvarchar(4000)"); store the base name so it matches the runtime
+        // fetch path (`type_name_for_tiberius`) and the other column types.
+        let base_name = type_name.split('(').next().unwrap_or(type_name).trim();
+        let type_info = MssqlTypeInfo::new(base_name.to_uppercase());
         let is_nullable: Option<bool> = row.get("is_nullable");
 
         let source_table: Option<&str> = row.get("source_table");

--- a/sqlx-mssql/src/error.rs
+++ b/sqlx-mssql/src/error.rs
@@ -93,12 +93,12 @@ impl DatabaseError for MssqlDatabaseError {
         match self.number {
             // Cannot insert duplicate key
             2601 | 2627 => ErrorKind::UniqueViolation,
-            // Foreign key constraint violation
+            // 547 is raised for both FOREIGN KEY and CHECK constraint
+            // violations; the message text distinguishes them.
+            547 if self.message.contains("CHECK constraint") => ErrorKind::CheckViolation,
             547 => ErrorKind::ForeignKeyViolation,
             // Cannot insert NULL
             515 => ErrorKind::NotNullViolation,
-            // Check constraint violation
-            2628 => ErrorKind::CheckViolation,
             _ => ErrorKind::Other,
         }
     }

--- a/sqlx-mssql/src/testing/mod.rs
+++ b/sqlx-mssql/src/testing/mod.rs
@@ -131,15 +131,23 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Mssql>, Error> {
 
     let mut conn = master_pool.acquire().await?;
 
-    // Create tracking table if it doesn't exist
+    // Create the tracking table if it doesn't exist. `IF NOT EXISTS ... CREATE`
+    // is not atomic across connections, so parallel `#[sqlx::test]`s can both
+    // pass the check and one then fails with 2714 ("already an object named
+    // '_sqlx_test_databases'"); swallow that race in TRY/CATCH.
     conn.execute(
         r#"
-        IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = '_sqlx_test_databases')
-        CREATE TABLE _sqlx_test_databases (
-            db_name NVARCHAR(200) NOT NULL PRIMARY KEY,
-            test_path NVARCHAR(MAX) NOT NULL,
-            created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
-        );
+        IF OBJECT_ID('_sqlx_test_databases', 'U') IS NULL
+        BEGIN TRY
+            CREATE TABLE _sqlx_test_databases (
+                db_name NVARCHAR(200) NOT NULL PRIMARY KEY,
+                test_path NVARCHAR(MAX) NOT NULL,
+                created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+            );
+        END TRY
+        BEGIN CATCH
+            IF ERROR_NUMBER() <> 2714 THROW;
+        END CATCH;
     "#,
     )
     .await?;

--- a/sqlx-mssql/src/type_checking.rs
+++ b/sqlx-mssql/src/type_checking.rs
@@ -12,6 +12,12 @@ impl_type_checking!(
         i16,
         i32,
         i64,
+
+        // Must come after the integer types: `bool::compatible` also matches
+        // TINYINT/INT/SMALLINT/BIGINT, but the integer types claim those first;
+        // BIT is matched only by `bool`.
+        bool,
+
         f32,
         f64,
 

--- a/sqlx-mssql/src/types/bigdecimal.rs
+++ b/sqlx-mssql/src/types/bigdecimal.rs
@@ -42,8 +42,13 @@ impl Decode<'_, Mssql> for BigDecimal {
                 .map_err(|e| format!("failed to convert Decimal to BigDecimal: {e}").into()),
             MssqlData::I32(v) => Ok(BigDecimal::from(*v)),
             MssqlData::I64(v) => Ok(BigDecimal::from(*v)),
-            MssqlData::F64(v) => bigdecimal::FromPrimitive::from_f64(*v)
-                .ok_or_else(|| format!("failed to convert f64 {v} to BigDecimal").into()),
+            // Go through the shortest round-tripping decimal string rather than
+            // `from_f64` (which keeps the full binary artifact, e.g. MONEY
+            // 1234.5678 -> 1234.567800000000033...).
+            MssqlData::F64(v) => v
+                .to_string()
+                .parse::<BigDecimal>()
+                .map_err(|e| format!("failed to convert f64 {v} to BigDecimal: {e}").into()),
             MssqlData::String(ref s) => s
                 .parse::<BigDecimal>()
                 .map_err(|e| format!("failed to parse BigDecimal from string: {e}").into()),

--- a/sqlx-mssql/src/types/bigdecimal.rs
+++ b/sqlx-mssql/src/types/bigdecimal.rs
@@ -31,7 +31,15 @@ impl Encode<'_, Mssql> for BigDecimal {
 impl Decode<'_, Mssql> for BigDecimal {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.data {
+            // When `rust_decimal` is also enabled it wins the decoder, so NUMERIC
+            // is stored as `MssqlData::Decimal`; convert it via its string form.
+            #[cfg(not(feature = "rust_decimal"))]
             MssqlData::BigDecimal(ref v) => Ok(v.clone()),
+            #[cfg(feature = "rust_decimal")]
+            MssqlData::Decimal(v) => v
+                .to_string()
+                .parse::<BigDecimal>()
+                .map_err(|e| format!("failed to convert Decimal to BigDecimal: {e}").into()),
             MssqlData::I32(v) => Ok(BigDecimal::from(*v)),
             MssqlData::I64(v) => Ok(BigDecimal::from(*v)),
             MssqlData::F64(v) => bigdecimal::FromPrimitive::from_f64(*v)

--- a/sqlx-mssql/src/types/time.rs
+++ b/sqlx-mssql/src/types/time.rs
@@ -30,8 +30,16 @@ impl Encode<'_, Mssql> for Date {
 impl Decode<'_, Mssql> for Date {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.data {
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimeDate(v) => Ok(*v),
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimePrimitiveDateTime(v) => Ok(v.date()),
+            // When `chrono` is also enabled it wins the decoder, so DATE is
+            // stored as a chrono variant; convert it to `time`.
+            #[cfg(feature = "chrono")]
+            MssqlData::NaiveDate(v) => date_from_chrono(*v),
+            #[cfg(feature = "chrono")]
+            MssqlData::NaiveDateTime(v) => date_from_chrono(v.date()),
             MssqlData::Null => Err("unexpected NULL".into()),
             _ => Err(format!("expected date, got {:?}", value.data).into()),
         }
@@ -60,8 +68,16 @@ impl Encode<'_, Mssql> for Time {
 impl Decode<'_, Mssql> for Time {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.data {
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimeTime(v) => Ok(*v),
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimePrimitiveDateTime(v) => Ok(v.time()),
+            // When `chrono` is also enabled it wins the decoder, so TIME is
+            // stored as a chrono variant; convert it to `time`.
+            #[cfg(feature = "chrono")]
+            MssqlData::NaiveTime(v) => time_from_chrono(*v),
+            #[cfg(feature = "chrono")]
+            MssqlData::NaiveDateTime(v) => time_from_chrono(v.time()),
             MssqlData::Null => Err("unexpected NULL".into()),
             _ => Err(format!("expected time, got {:?}", value.data).into()),
         }
@@ -90,7 +106,15 @@ impl Encode<'_, Mssql> for PrimitiveDateTime {
 impl Decode<'_, Mssql> for PrimitiveDateTime {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.data {
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimePrimitiveDateTime(v) => Ok(*v),
+            // When `chrono` is also enabled it wins the decoder, so DATETIME2 is
+            // stored as `MssqlData::NaiveDateTime`; convert it to `time`.
+            #[cfg(feature = "chrono")]
+            MssqlData::NaiveDateTime(v) => Ok(PrimitiveDateTime::new(
+                date_from_chrono(v.date())?,
+                time_from_chrono(v.time())?,
+            )),
             MssqlData::Null => Err("unexpected NULL".into()),
             _ => Err(format!("expected datetime, got {:?}", value.data).into()),
         }
@@ -119,10 +143,61 @@ impl Encode<'_, Mssql> for OffsetDateTime {
 impl Decode<'_, Mssql> for OffsetDateTime {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.data {
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimeOffsetDateTime(v) => Ok(*v),
+            #[cfg(not(feature = "chrono"))]
             MssqlData::TimePrimitiveDateTime(v) => Ok(v.assume_utc()),
+            // When `chrono` is also enabled it wins the decoder, so
+            // DATETIMEOFFSET is stored as `MssqlData::DateTimeFixedOffset` (and
+            // DATETIME2 as `NaiveDateTime`); convert to `time`.
+            #[cfg(feature = "chrono")]
+            MssqlData::DateTimeFixedOffset(v) => {
+                let local = v.naive_local();
+                let offset = time::UtcOffset::from_whole_seconds(v.offset().local_minus_utc())?;
+                Ok(
+                    PrimitiveDateTime::new(date_from_chrono(local.date())?, time_from_chrono(local.time())?)
+                        .assume_offset(offset),
+                )
+            }
+            #[cfg(feature = "chrono")]
+            MssqlData::NaiveDateTime(v) => Ok(PrimitiveDateTime::new(
+                date_from_chrono(v.date())?,
+                time_from_chrono(v.time())?,
+            )
+            .assume_utc()),
             MssqlData::Null => Err("unexpected NULL".into()),
             _ => Err(format!("expected datetimeoffset, got {:?}", value.data).into()),
         }
     }
+}
+
+/// Convert a `chrono::NaiveDate` to a `time::Date`.
+///
+/// Needed only when both `chrono` and `time` are enabled: the decoder stores
+/// temporal values as chrono variants (chrono wins), so the `time` `Decode`
+/// impls must convert.
+#[cfg(feature = "chrono")]
+fn date_from_chrono(d: chrono::NaiveDate) -> Result<Date, BoxDynError> {
+    use chrono::Datelike as _;
+    let month = time::Month::try_from(u8::try_from(d.month())?)?;
+    Ok(Date::from_calendar_date(
+        d.year(),
+        month,
+        u8::try_from(d.day())?,
+    )?)
+}
+
+/// Convert a `chrono::NaiveTime` to a `time::Time`.
+///
+/// Leap-second nanoseconds (≥ 1e9) are clamped to the last representable
+/// nanosecond, since `time::Time` has no leap-second representation.
+#[cfg(feature = "chrono")]
+fn time_from_chrono(t: chrono::NaiveTime) -> Result<Time, BoxDynError> {
+    use chrono::Timelike as _;
+    Ok(Time::from_hms_nano(
+        u8::try_from(t.hour())?,
+        u8::try_from(t.minute())?,
+        u8::try_from(t.second())?,
+        std::cmp::min(t.nanosecond(), 999_999_999),
+    )?)
 }

--- a/sqlx-mssql/src/types/time.rs
+++ b/sqlx-mssql/src/types/time.rs
@@ -154,10 +154,11 @@ impl Decode<'_, Mssql> for OffsetDateTime {
             MssqlData::DateTimeFixedOffset(v) => {
                 let local = v.naive_local();
                 let offset = time::UtcOffset::from_whole_seconds(v.offset().local_minus_utc())?;
-                Ok(
-                    PrimitiveDateTime::new(date_from_chrono(local.date())?, time_from_chrono(local.time())?)
-                        .assume_offset(offset),
+                Ok(PrimitiveDateTime::new(
+                    date_from_chrono(local.date())?,
+                    time_from_chrono(local.time())?,
                 )
+                .assume_offset(offset))
             }
             #[cfg(feature = "chrono")]
             MssqlData::NaiveDateTime(v) => Ok(PrimitiveDateTime::new(

--- a/sqlx-mssql/src/value.rs
+++ b/sqlx-mssql/src/value.rs
@@ -200,14 +200,11 @@ pub(crate) fn column_data_to_mssql_data(
             let fixed_offset = chrono::FixedOffset::east_opt(offset_secs).ok_or_else(|| {
                 Error::Protocol(format!("invalid timezone offset: {offset_secs} seconds"))
             })?;
-            let dt = naive
-                .and_local_timezone(fixed_offset)
-                .single()
-                .ok_or_else(|| {
-                    Error::Protocol(format!(
-                        "ambiguous or invalid local time for offset {offset_secs}s"
-                    ))
-                })?;
+            // The TDS DATETIMEOFFSET datetime portion is stored in UTC; attach
+            // UTC and convert to the stored offset (so `14:30+05:30` round-trips
+            // rather than being reinterpreted as `09:00+05:30`).
+            let dt = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(naive, chrono::Utc)
+                .with_timezone(&fixed_offset);
             Ok(MssqlData::DateTimeFixedOffset(dt))
         }
 

--- a/sqlx-sqlite/src/regexp.rs
+++ b/sqlx-sqlite/src/regexp.rs
@@ -138,7 +138,7 @@ unsafe fn get_regex_from_arg(
 
 /// Get a text reference of the value of `arg`. Returns `None` for NULL values.
 ///
-/// For non-NULL values, `sqlite3_value_text()` is called directly, which lets SQLite
+/// For non-NULL values, `sqlite3_value_text()` is called directly, which lets `SQLite`
 /// coerce INTEGER, REAL, and BLOB values to their text representation. This matches
 /// the coercion behavior documented at <https://www.sqlite.org/c3ref/value_blob.html>.
 ///

--- a/tests/any/any.rs
+++ b/tests/any/any.rs
@@ -161,9 +161,11 @@ async fn it_can_query_by_string_args() -> sqlx::Result<()> {
 
     // MSSQL's native placeholder is `@pN` (the `Any` driver does not rewrite
     // placeholders), so it needs its own branch like Postgres above.
+    // SQL Server requires every column of a derived table to be named, so the
+    // subquery column is aliased (`AS n`); error 8155 otherwise.
     #[cfg(all(feature = "mssql", not(feature = "postgres")))]
     const SQL: &str = "SELECT 'Hello, world!' \
-        FROM (SELECT 1) AS t \
+        FROM (SELECT 1 AS n) AS t \
         WHERE 'Hello, world!' IN (@p1, @p2, @p3, @p4, @p5, @p6, @p7)";
 
     // MySQL and SQLite use `?` natively.

--- a/tests/any/any.rs
+++ b/tests/any/any.rs
@@ -159,7 +159,15 @@ async fn it_can_query_by_string_args() -> sqlx::Result<()> {
         FROM (SELECT 1) AS t \
         WHERE 'Hello, world!' IN ($1, $2, $3, $4, $5, $6, $7)";
 
-    #[cfg(not(feature = "postgres"))]
+    // MSSQL's native placeholder is `@pN` (the `Any` driver does not rewrite
+    // placeholders), so it needs its own branch like Postgres above.
+    #[cfg(all(feature = "mssql", not(feature = "postgres")))]
+    const SQL: &str = "SELECT 'Hello, world!' \
+        FROM (SELECT 1) AS t \
+        WHERE 'Hello, world!' IN (@p1, @p2, @p3, @p4, @p5, @p6, @p7)";
+
+    // MySQL and SQLite use `?` natively.
+    #[cfg(all(not(feature = "postgres"), not(feature = "mssql")))]
     const SQL: &str = "SELECT 'Hello, world!' \
         FROM (SELECT 1) AS t \
         WHERE 'Hello, world!' IN (?, ?, ?, ?, ?, ?, ?)";

--- a/tests/any/any.rs
+++ b/tests/any/any.rs
@@ -172,7 +172,7 @@ async fn it_can_query_by_string_args() -> sqlx::Result<()> {
             .bind(Some(&string))
             .bind(Some(&string[..]))
             .bind(&Option::<String>::None)
-            .bind(&string.clone())
+            .bind(string.clone())
             .bind(&tuple.0); // should not get "temporary value is freed at the end of this statement" here
 
         let result = query.fetch_one(&mut conn).await?;
@@ -192,7 +192,7 @@ async fn it_can_query_by_string_args() -> sqlx::Result<()> {
             query.try_bind(Some(&string))?;
             query.try_bind(Some(&string[..]))?;
             query.try_bind(&Option::<String>::None)?;
-            query.try_bind(&string.clone())?;
+            query.try_bind(string.clone())?;
             query.try_bind(&tuple.0)?;
 
             Ok(query)

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -84,6 +84,17 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
 
     sqlx_test::setup_if_needed();
 
+    // MSSQL has no `CREATE TEMPORARY TABLE`; it uses session-scoped temp tables
+    // named with a leading `#` (which persist for the connection's session).
+    #[cfg(feature = "mssql")]
+    const TABLE: &str = "#conn_stats";
+    #[cfg(feature = "mssql")]
+    const CREATE_TABLE: &str = "CREATE TABLE";
+    #[cfg(not(feature = "mssql"))]
+    const TABLE: &str = "conn_stats";
+    #[cfg(not(feature = "mssql"))]
+    const CREATE_TABLE: &str = "CREATE TEMPORARY TABLE";
+
     let conn_options: AnyConnectOptions = std::env::var("DATABASE_URL")?.parse()?;
 
     let current_id = AtomicI32::new(0);
@@ -101,15 +112,13 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
                 let statement = format!(
                     // language=SQL
                     r#"
-                    CREATE TEMPORARY TABLE conn_stats(
+                    {CREATE_TABLE} {TABLE}(
                         id int primary key,
                         before_acquire_calls int default 0,
                         after_release_calls int default 0
                     );
-                    INSERT INTO conn_stats(id) VALUES ({});
-                    "#,
-                    // Until we have generalized bind parameters
-                    id
+                    INSERT INTO {TABLE}(id) VALUES ({id});
+                    "#
                 );
 
                 conn.execute(AssertSqlSafe(statement)).await?;
@@ -123,18 +132,16 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
 
             Box::pin(async move {
                 // MySQL and MariaDB don't support UPDATE ... RETURNING
-                sqlx::query(
-                    r#"
-                        UPDATE conn_stats
-                        SET before_acquire_calls = before_acquire_calls + 1
-                    "#,
-                )
+                sqlx::query(AssertSqlSafe(format!(
+                    "UPDATE {TABLE} SET before_acquire_calls = before_acquire_calls + 1"
+                )))
                 .execute(&mut *conn)
                 .await?;
 
-                let stats: ConnStats = sqlx::query_as("SELECT * FROM conn_stats")
-                    .fetch_one(conn)
-                    .await?;
+                let stats: ConnStats =
+                    sqlx::query_as(AssertSqlSafe(format!("SELECT * FROM {TABLE}")))
+                        .fetch_one(conn)
+                        .await?;
 
                 // For even IDs, cap by the number of before_acquire calls.
                 // Ignore the check for odd IDs.
@@ -147,18 +154,16 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
             assert_eq!(meta.idle_for, Duration::ZERO);
 
             Box::pin(async move {
-                sqlx::query(
-                    r#"
-                        UPDATE conn_stats
-                        SET after_release_calls = after_release_calls + 1
-                    "#,
-                )
+                sqlx::query(AssertSqlSafe(format!(
+                    "UPDATE {TABLE} SET after_release_calls = after_release_calls + 1"
+                )))
                 .execute(&mut *conn)
                 .await?;
 
-                let stats: ConnStats = sqlx::query_as("SELECT * FROM conn_stats")
-                    .fetch_one(conn)
-                    .await?;
+                let stats: ConnStats =
+                    sqlx::query_as(AssertSqlSafe(format!("SELECT * FROM {TABLE}")))
+                        .fetch_one(conn)
+                        .await?;
 
                 // For odd IDs, cap by the number of before_release calls.
                 // Ignore the check for even IDs.
@@ -186,7 +191,7 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
     ];
 
     for (id, before_acquire_calls, after_release_calls) in pattern {
-        let conn_stats: ConnStats = sqlx::query_as("SELECT * FROM conn_stats")
+        let conn_stats: ConnStats = sqlx::query_as(AssertSqlSafe(format!("SELECT * FROM {TABLE}")))
             .fetch_one(&pool)
             .await?;
 

--- a/tests/mssql/Dockerfile
+++ b/tests/mssql/Dockerfile
@@ -1,6 +1,10 @@
 ARG VERSION
 FROM mcr.microsoft.com/mssql/server:${VERSION}
 
+# The base image now defaults to the non-root `mssql` user (UID 10001), which
+# cannot create directories under /usr; switch to root for the setup steps.
+USER root
+
 # Create a config directory
 RUN mkdir -p /usr/config
 WORKDIR /usr/config
@@ -10,8 +14,7 @@ COPY mssql/entrypoint.sh /usr/config/entrypoint.sh
 COPY mssql/configure-db.sh /usr/config/configure-db.sh
 COPY mssql/setup.sql /usr/config/setup.sql
 
-# Grant permissions for to our scripts to be executable
-USER root
+# Grant permissions for to our scripts to be executable (already root)
 RUN chmod +x /usr/config/entrypoint.sh
 RUN chmod +x /usr/config/configure-db.sh
 RUN chown 10001 /usr/config/entrypoint.sh

--- a/tests/mssql/bulk-insert.rs
+++ b/tests/mssql/bulk-insert.rs
@@ -1,3 +1,9 @@
+// These tests use global temp tables (`##name`) rather than local (`#name`):
+// tiberius' `bulk_insert` fetches column metadata via `SELECT TOP 0 * FROM
+// <table>` on a separate batch that can't see a session-local temp table, so
+// local temp tables fail with "Invalid object name". (tiberius' own docs use
+// `##` for this.) The distinct names and per-test connections keep them safe to
+// run in parallel; each drops when its creating session closes.
 use sqlx::mssql::{IntoRow, Mssql};
 use sqlx::Row;
 use sqlx_test::new;
@@ -6,18 +12,18 @@ use sqlx_test::new;
 async fn it_bulk_inserts_rows() -> anyhow::Result<()> {
     let mut conn = new::<Mssql>().await?;
 
-    sqlx::query("CREATE TABLE #bulk_test (name NVARCHAR(50) NOT NULL, value INT NOT NULL)")
+    sqlx::query("CREATE TABLE ##bulk_test (name NVARCHAR(50) NOT NULL, value INT NOT NULL)")
         .execute(&mut conn)
         .await?;
 
-    let mut bulk = conn.bulk_insert("#bulk_test").await?;
+    let mut bulk = conn.bulk_insert("##bulk_test").await?;
     bulk.send(("hello", 1i32).into_row()).await?;
     bulk.send(("world", 2i32).into_row()).await?;
     bulk.send(("foo", 3i32).into_row()).await?;
     let total = bulk.finalize().await?;
     assert_eq!(total, 3);
 
-    let rows = sqlx::query("SELECT name, value FROM #bulk_test ORDER BY value")
+    let rows = sqlx::query("SELECT name, value FROM ##bulk_test ORDER BY value")
         .fetch_all(&mut conn)
         .await?;
 
@@ -36,11 +42,11 @@ async fn it_bulk_inserts_rows() -> anyhow::Result<()> {
 async fn it_bulk_inserts_empty() -> anyhow::Result<()> {
     let mut conn = new::<Mssql>().await?;
 
-    sqlx::query("CREATE TABLE #bulk_empty (id INT NOT NULL)")
+    sqlx::query("CREATE TABLE ##bulk_empty (id INT NOT NULL)")
         .execute(&mut conn)
         .await?;
 
-    let bulk = conn.bulk_insert("#bulk_empty").await?;
+    let bulk = conn.bulk_insert("##bulk_empty").await?;
     let total = bulk.finalize().await?;
     assert_eq!(total, 0);
 
@@ -52,18 +58,18 @@ async fn it_bulk_inserts_various_types() -> anyhow::Result<()> {
     let mut conn = new::<Mssql>().await?;
 
     sqlx::query(
-        "CREATE TABLE #bulk_types (id INT NOT NULL, label NVARCHAR(100) NOT NULL, score FLOAT NOT NULL)"
+        "CREATE TABLE ##bulk_types (id INT NOT NULL, label NVARCHAR(100) NOT NULL, score FLOAT NOT NULL)"
     )
     .execute(&mut conn)
     .await?;
 
-    let mut bulk = conn.bulk_insert("#bulk_types").await?;
+    let mut bulk = conn.bulk_insert("##bulk_types").await?;
     bulk.send((1i32, "alpha", 1.5f64).into_row()).await?;
     bulk.send((2i32, "beta", 2.7f64).into_row()).await?;
     let total = bulk.finalize().await?;
     assert_eq!(total, 2);
 
-    let rows = sqlx::query("SELECT id, label, score FROM #bulk_types ORDER BY id")
+    let rows = sqlx::query("SELECT id, label, score FROM ##bulk_types ORDER BY id")
         .fetch_all(&mut conn)
         .await?;
 

--- a/tests/mssql/configure-db.sh
+++ b/tests/mssql/configure-db.sh
@@ -3,5 +3,14 @@
 # Wait 60 seconds for SQL Server to start up
 sleep 60
 
+# Recent mcr.microsoft.com/mssql/server images ship sqlcmd at
+# /opt/mssql-tools18 (ODBC Driver 18, which encrypts by default -> needs -C to
+# trust the container's self-signed cert); older images used /opt/mssql-tools.
+if [ -x /opt/mssql-tools18/bin/sqlcmd ]; then
+    SQLCMD=(/opt/mssql-tools18/bin/sqlcmd -C)
+else
+    SQLCMD=(/opt/mssql-tools/bin/sqlcmd)
+fi
+
 # Run the setup script to create the DB and the schema in the DB
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql
+"${SQLCMD[@]}" -S localhost -U sa -P "$SA_PASSWORD" -d master -i setup.sql

--- a/tests/mssql/migrations_simple/20220721115524_convert_type.sql
+++ b/tests/mssql/migrations_simple/20220721115524_convert_type.sql
@@ -10,8 +10,9 @@ ADD some_payload_tmp NVARCHAR(MAX);
 -- This will fail if `some_payload` is already a string column due to the addition.
 -- We add a suffix after the addition to ensure that the SQL database does not silently cast the string back to an
 -- integer.
-UPDATE migrations_simple_test
-SET some_payload_tmp = CONCAT(CAST((some_payload + 10) AS VARCHAR(3)), '_suffix');
+-- Wrapped in EXEC() because a column added by ALTER ... ADD is not visible to
+-- DML in the same batch (SQL Server resolves column names at batch compile).
+EXEC('UPDATE migrations_simple_test SET some_payload_tmp = CONCAT(CAST((some_payload + 10) AS VARCHAR(3)), ''_suffix'')');
 
 -- remove original column including the content
 ALTER TABLE migrations_simple_test
@@ -21,9 +22,8 @@ DROP COLUMN some_payload;
 ALTER TABLE migrations_simple_test
 ADD some_payload NVARCHAR(MAX);
 
--- copy new values
-UPDATE migrations_simple_test
-SET some_payload = some_payload_tmp;
+-- copy new values (EXEC for the same reason as above)
+EXEC('UPDATE migrations_simple_test SET some_payload = some_payload_tmp');
 
 -- "freeze" column: MSSQL uses sp_rename + re-add or ALTER COLUMN for NOT NULL
 ALTER TABLE migrations_simple_test

--- a/tests/mssql/mssql.rs
+++ b/tests/mssql/mssql.rs
@@ -2,7 +2,10 @@ use futures_util::TryStreamExt;
 use sqlx::mssql::MssqlRow;
 use sqlx::mssql::{Mssql, MssqlPoolOptions};
 use sqlx::mssql::{MssqlAdvisoryLock, MssqlIsolationLevel};
-use sqlx::{Column, Connection, Executor, MssqlConnection, Row, SqlSafeStr, Statement, TypeInfo};
+use sqlx::{
+    AssertSqlSafe, Column, Connection, Either, Executor, MssqlConnection, Row, SqlSafeStr,
+    Statement, TypeInfo,
+};
 use sqlx_test::new;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::Duration;
@@ -114,6 +117,52 @@ CREATE TABLE #users (id INTEGER PRIMARY KEY);
         .await?;
 
     assert_eq!(sum, 110);
+
+    Ok(())
+}
+
+// Regression test: parameterized INSERT/UPDATE/DELETE must report the real
+// affected-row count from SQL Server's DONE token, not 0. The execute path goes
+// through tiberius `execute()` (ExecuteResult) rather than the row-counting
+// fetch path.
+#[sqlx_macros::test]
+async fn it_reports_rows_affected_for_dml() -> anyhow::Result<()> {
+    let mut conn = new::<Mssql>().await?;
+
+    conn.execute("CREATE TABLE #widgets (id INTEGER PRIMARY KEY, label NVARCHAR(50) NULL);")
+        .await?;
+
+    for index in 1..=5_i32 {
+        let done = sqlx::query("INSERT INTO #widgets (id) VALUES (@p1)")
+            .bind(index)
+            .execute(&mut conn)
+            .await?;
+        assert_eq!(done.rows_affected(), 1);
+    }
+
+    // UPDATE that hits exactly one row.
+    let done = sqlx::query("UPDATE #widgets SET label = @p1 WHERE id = @p2")
+        .bind("hit")
+        .bind(3_i32)
+        .execute(&mut conn)
+        .await?;
+    assert_eq!(done.rows_affected(), 1);
+
+    // UPDATE that matches no rows -> 0. This proves the count is real, not just
+    // "always non-zero".
+    let done = sqlx::query("UPDATE #widgets SET label = @p1 WHERE id = @p2")
+        .bind("miss")
+        .bind(999_i32)
+        .execute(&mut conn)
+        .await?;
+    assert_eq!(done.rows_affected(), 0);
+
+    // Multi-row DELETE reports the number of rows removed.
+    let done = sqlx::query("DELETE FROM #widgets WHERE id >= @p1")
+        .bind(3_i32)
+        .execute(&mut conn)
+        .await?;
+    assert_eq!(done.rows_affected(), 3);
 
     Ok(())
 }
@@ -467,37 +516,26 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
 async fn it_can_query_multiple_result_sets() -> anyhow::Result<()> {
     let mut conn = new::<Mssql>().await?;
 
-    // A batch that produces two result sets
-    let results = conn
-        .run("SELECT 1 AS a; SELECT 2 AS b, 3 AS c;", None)
+    // A batch that produces two result sets. `fetch_many` streams the rows from
+    // every result set in order, interleaved with `Either::Left` query-result
+    // markers.
+    let results: Vec<Either<_, _>> = (&mut conn)
+        .fetch_many("SELECT 1 AS a; SELECT 2 AS b, 3 AS c;")
+        .try_collect()
         .await?;
 
-    // First result set: one row with column "a"
-    let mut rows_first = Vec::new();
-    let mut rows_second = Vec::new();
-    let mut result_count = 0;
+    let rows: Vec<_> = results
+        .iter()
+        .filter_map(|item| item.as_ref().right())
+        .collect();
 
-    for item in &results {
-        match item {
-            either::Either::Left(_) => {
-                result_count += 1;
-            }
-            either::Either::Right(row) => {
-                if result_count == 0 {
-                    rows_first.push(row);
-                } else {
-                    rows_second.push(row);
-                }
-            }
-        }
-    }
+    // First result set: one row with column "a".
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].try_get::<i32, _>("a")?, 1);
 
-    assert_eq!(rows_first.len(), 1);
-    assert_eq!(rows_first[0].try_get::<i32, _>("a")?, 1);
-
-    assert_eq!(rows_second.len(), 1);
-    assert_eq!(rows_second[0].try_get::<i32, _>("b")?, 2);
-    assert_eq!(rows_second[0].try_get::<i32, _>("c")?, 3);
+    // Second result set: one row with columns "b" and "c".
+    assert_eq!(rows[1].try_get::<i32, _>("b")?, 2);
+    assert_eq!(rows[1].try_get::<i32, _>("c")?, 3);
 
     Ok(())
 }
@@ -551,7 +589,7 @@ async fn it_can_bind_many_parameters() -> anyhow::Result<()> {
     let param_refs: Vec<String> = (1..=100).map(|i| format!("@p{i}")).collect();
     let sql = format!("SELECT {}", param_refs.join(" + "));
 
-    let mut query = sqlx::query_scalar::<_, i32>(&sql);
+    let mut query = sqlx::query_scalar::<_, i32>(AssertSqlSafe(sql));
     for _ in 0..100 {
         query = query.bind(1_i32);
     }

--- a/tests/mssql/mssql.rs
+++ b/tests/mssql/mssql.rs
@@ -48,7 +48,10 @@ async fn it_can_select_expression_by_name() -> anyhow::Result<()> {
 #[sqlx_macros::test]
 async fn it_can_fail_to_connect() -> anyhow::Result<()> {
     let mut url = dotenvy::var("DATABASE_URL")?;
-    url = url.replace("Password", "NotPassword");
+    // Corrupt the password to force an authentication failure. The configured
+    // password doesn't literally contain "Password" (e.g. "YourStrong!Passw0rd"),
+    // so prefix the `sa:` credential rather than rely on a specific substring.
+    url = url.replacen("sa:", "sa:wrong-", 1);
 
     let res = MssqlConnection::connect(&url).await;
     let err = res.unwrap_err();

--- a/tests/mssql/run-local.sh
+++ b/tests/mssql/run-local.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Run the MSSQL integration tests locally, mirroring the CI `MSSQL` job in
+# .github/workflows/mssql.yml. Spins up the same SQL Server container, waits for
+# the `sqlx` database to be created, then runs only the mssql-using integration
+# tests with the same features and environment as CI.
+#
+# Usage:
+#   tests/mssql/run-local.sh [extra cargo test args...]   # run the suite
+#   tests/mssql/run-local.sh --test mssql                 # run one target
+#   tests/mssql/run-local.sh --down                       # stop & remove container
+#   MSSQL_VERSION=2019 tests/mssql/run-local.sh           # use the 2019 image
+#
+# The container is left running between invocations for fast iteration; use
+# `--down` to remove it.
+set -euo pipefail
+
+MSSQL_VERSION="${MSSQL_VERSION:-2022}"
+SERVICE="mssql_${MSSQL_VERSION}"
+CONTAINER="sqlx_mssql_local_${MSSQL_VERSION}"
+PASSWORD='YourStrong!Passw0rd'
+FEATURES="any,mssql,macros,migrate,_unstable-all-types,runtime-tokio,tls-none"
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if [[ "${1:-}" == "--down" ]]; then
+    echo ">> removing container $CONTAINER"
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    exit 0
+fi
+
+# Start the container if it isn't already running.
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+    echo ">> starting $SERVICE as $CONTAINER (first run builds the image)"
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker compose -f tests/docker-compose.yml run -d -p 1433:1433 --name "$CONTAINER" "$SERVICE"
+else
+    echo ">> reusing running container $CONTAINER"
+fi
+
+# Poll until the `sqlx` database exists. The container's configure-db.sh sleeps
+# ~60s then creates it; use the same sqlcmd the image ships (tools18, which
+# encrypts by default -> -C), with $SA_PASSWORD already set inside the container.
+echo ">> waiting for the 'sqlx' database..."
+ready=
+for i in $(seq 1 60); do
+    if docker exec "$CONTAINER" bash -c '
+        S=/opt/mssql-tools18/bin/sqlcmd; C=-C
+        [ -x "$S" ] || { S=/opt/mssql-tools/bin/sqlcmd; C=; }
+        "$S" $C -S localhost -U sa -P "$SA_PASSWORD" -d sqlx -Q "SELECT 1" -b
+    ' >/dev/null 2>&1; then
+        echo ">> sqlx database ready (after ~$((i * 5))s)"
+        ready=1
+        break
+    fi
+    sleep 5
+done
+if [[ -z "$ready" ]]; then
+    echo "!! sqlx database never came up; last container logs:" >&2
+    docker logs "$CONTAINER" 2>&1 | tail -30 >&2
+    exit 1
+fi
+
+mkdir -p .sqlx
+export DATABASE_URL="mssql://sa:${PASSWORD}@localhost:1433/sqlx?sslmode=disabled"
+export SQLX_OFFLINE_DIR=".sqlx"
+export RUSTFLAGS="--cfg mssql_${MSSQL_VERSION}"
+
+echo ">> cargo test (features: $FEATURES)"
+cargo test --no-default-features --features "$FEATURES" "$@"

--- a/tests/mssql/test-attr.rs
+++ b/tests/mssql/test-attr.rs
@@ -71,7 +71,7 @@ async fn it_gets_posts(pool: MssqlPool) -> sqlx::Result<()> {
 async fn it_gets_comments(pool: MssqlPool) -> sqlx::Result<()> {
     let post_1_comments: Vec<String> =
         sqlx::query_scalar("SELECT content FROM comment WHERE post_id = @p1 ORDER BY created_at")
-            .bind(&1)
+            .bind(1)
             .fetch_all(&pool)
             .await?;
 
@@ -82,7 +82,7 @@ async fn it_gets_comments(pool: MssqlPool) -> sqlx::Result<()> {
 
     let post_2_comments: Vec<String> =
         sqlx::query_scalar("SELECT content FROM comment WHERE post_id = @p1 ORDER BY created_at")
-            .bind(&2)
+            .bind(2)
             .fetch_all(&pool)
             .await?;
 

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -5,7 +5,7 @@
 extern crate time_ as time;
 
 use sqlx::mssql::Mssql;
-use sqlx_test::test_type;
+use sqlx_test::{test_type, test_unprepared_type};
 
 test_type!(null<Option<i32>>(Mssql,
     "CAST(NULL as INT)" == None::<i32>
@@ -146,7 +146,10 @@ test_type!(null_bytes<Option<Vec<u8>>>(Mssql,
     "CAST(NULL AS VARBINARY(MAX))" == None::<Vec<u8>>,
 ));
 
-test_type!(xml<sqlx::mssql::MssqlXml>(Mssql,
+// SQL Server has no equality operator for the `xml` type (`xml = @p1` raises
+// error 402), so the prepared round-trip query the full `test_type!` macro
+// generates can't work; decode and compare in Rust instead.
+test_unprepared_type!(xml<sqlx::mssql::MssqlXml>(Mssql,
     "CAST('<root><item>hello</item></root>' AS XML)"
         == sqlx::mssql::MssqlXml::from("<root><item>hello</item></root>".to_owned()),
 ));

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -1,3 +1,7 @@
+// Several `test_type!` cases use float literals close to PI / with more
+// precision than the type holds, on purpose, to exercise round-tripping.
+#![allow(clippy::approx_constant, clippy::excessive_precision)]
+
 extern crate time_ as time;
 
 use sqlx::mssql::Mssql;

--- a/tests/mysql/derives.rs
+++ b/tests/mysql/derives.rs
@@ -143,6 +143,11 @@ async fn test_derive_strong_enum() -> anyhow::Result<()> {
     Ok(())
 }
 
+// This test derives `sqlx::Type` for `#[repr(u16/u32/u64)]` enums, which cannot
+// generate a Postgres impl (Postgres has no unsigned integer types). Skip it
+// when the `postgres` feature is also enabled (e.g. under `--all-features`); it
+// still runs under the MySQL feature set.
+#[cfg(not(feature = "postgres"))]
 #[sqlx::test]
 async fn test_derive_weak_enum() -> anyhow::Result<()> {
     #[derive(sqlx::Type, Debug, PartialEq, Eq)]

--- a/tests/mysql/describe.rs
+++ b/tests/mysql/describe.rs
@@ -53,8 +53,8 @@ CREATE TEMPORARY TABLE with_bit_and_tinyint (
     assert_eq!(d.column(1).name(), "value_bit_1");
     assert_eq!(d.column(1).type_info().name(), "BIT");
 
-    assert!(<bool as Type<MySql>>::compatible(&d.column(1).type_info()));
-    assert!(<bool as Type<MySql>>::compatible(&d.column(2).type_info()));
+    assert!(<bool as Type<MySql>>::compatible(d.column(1).type_info()));
+    assert!(<bool as Type<MySql>>::compatible(d.column(2).type_info()));
 
     Ok(())
 }

--- a/tests/mysql/error.rs
+++ b/tests/mysql/error.rs
@@ -6,7 +6,7 @@ fn mysql_supports_check_constraints(version: &str) -> bool {
         return true;
     }
 
-    let numeric = match version.split(|c| c == '-' || c == ' ').next() {
+    let numeric = match version.split(['-', ' ']).next() {
         Some(numeric) => numeric,
         None => return false,
     };

--- a/tests/mysql/test-attr.rs
+++ b/tests/mysql/test-attr.rs
@@ -153,7 +153,7 @@ async fn it_gets_posts_custom_relative_fixtures_path(pool: MySqlPool) -> sqlx::R
 async fn it_gets_comments(pool: MySqlPool) -> sqlx::Result<()> {
     let post_1_comments: Vec<String> =
         sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
-            .bind(&1)
+            .bind(1)
             .fetch_all(&pool)
             .await?;
 
@@ -164,7 +164,7 @@ async fn it_gets_comments(pool: MySqlPool) -> sqlx::Result<()> {
 
     let post_2_comments: Vec<String> =
         sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
-            .bind(&2)
+            .bind(2)
             .fetch_all(&pool)
             .await?;
 

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -1,3 +1,6 @@
+// `f64`/`f32` `test_type!` cases use literals close to PI on purpose.
+#![allow(clippy::approx_constant)]
+
 extern crate time_ as time;
 
 use std::borrow::Cow;

--- a/tests/sqlite/derives.rs
+++ b/tests/sqlite/derives.rs
@@ -1,6 +1,10 @@
 use sqlx::Sqlite;
 use sqlx_test::test_type;
 
+// A `#[repr(u32)]` enum cannot derive `sqlx::Type` for Postgres (Postgres has no
+// unsigned integer types), so skip this when the `postgres` feature is also
+// enabled (e.g. under `--all-features`); it still runs under the SQLite set.
+#[cfg(not(feature = "postgres"))]
 #[derive(Debug, PartialEq, sqlx::Type)]
 #[repr(u32)]
 enum Origin {
@@ -8,6 +12,7 @@ enum Origin {
     Bar = 2,
 }
 
+#[cfg(not(feature = "postgres"))]
 test_type!(origin_enum<Origin>(Sqlite,
     "1" == Origin::Foo,
     "2" == Origin::Bar,

--- a/tests/sqlite/test-attr.rs
+++ b/tests/sqlite/test-attr.rs
@@ -78,7 +78,7 @@ async fn it_gets_posts(pool: SqlitePool) -> sqlx::Result<()> {
 async fn it_gets_comments(pool: SqlitePool) -> sqlx::Result<()> {
     let post_1_comments: Vec<String> =
         sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
-            .bind(&1)
+            .bind(1)
             .fetch_all(&pool)
             .await?;
 
@@ -89,7 +89,7 @@ async fn it_gets_comments(pool: SqlitePool) -> sqlx::Result<()> {
 
     let post_2_comments: Vec<String> =
         sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
-            .bind(&2)
+            .bind(2)
             .fetch_all(&pool)
             .await?;
 

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -1,3 +1,6 @@
+// `f32` `test_type!` cases use a literal close to PI on purpose.
+#![allow(clippy::approx_constant)]
+
 extern crate time_ as time;
 
 use sqlx::sqlite::{Sqlite, SqliteRow};
@@ -116,7 +119,7 @@ mod chrono {
     ));
 
     test_type!(chrono_date_time_fixed_offset<DateTime::<FixedOffset>>(Sqlite, "SELECT datetime({0}) is datetime(?), {0}, ?",
-        "'2016-11-08T03:50:23-05:00'" == DateTime::<Utc>::from(FixedOffset::west_opt(5 * 3600).unwrap().with_ymd_and_hms(2016, 11, 08, 3, 50, 23).unwrap())
+        "'2016-11-08T03:50:23-05:00'" == DateTime::<Utc>::from(FixedOffset::west_opt(5 * 3600).unwrap().with_ymd_and_hms(2016, 11, 8, 3, 50, 23).unwrap())
     ));
 }
 


### PR DESCRIPTION
The driver routed every statement (including .execute()) through the tiberius query() path, whose QueryStream silently drops the DONE/DONEINPROC tokens that carry SQL Server's affected-row count, and then derived rows_affected by counting returned rows. INSERT/UPDATE/DELETE return no rows, so rows_affected() was always 0 — breaking the idiomatic `if rows_affected() == 0` guard.

Drive parameterized execute statements through tiberius execute() instead, whose ExecuteResult reads the DONE tokens and exposes the true count:

- Extract the param-binding match into a shared bind_arguments() helper.
- Add MssqlConnection::run_execute(), returning one MssqlQueryResult per statement with the real count.
- Override Executor::execute_many: parameterized statements use run_execute() (accurate counts); no-parameter statements stay on the plain-batch simple_query() path, which is required for DDL such as CREATE PROCEDURE/VIEW/TRIGGER in migrations. fetch_many/fetch_optional are unchanged.

Add it_reports_rows_affected_for_dml covering INSERT, UPDATE hitting one row, UPDATE matching nothing (== 0), and multi-row DELETE.

Also fix pre-existing compile errors in tests/mssql/mssql.rs that blocked the whole test binary from building (independent of this change): it_can_query_multiple_result_sets called the crate-private conn.run() and the unlinked `either` crate; it_can_bind_many_parameters passed a dynamic String to query_scalar without AssertSqlSafe.

Author: Pablo Carrera <pabloce@poscye.com>

<!-- 
PR AUTHOR INSTRUCTIONS; PLEASE READ.

Give your pull request an accurate and descriptive title. It should mention what component(s) or database driver(s) it touches.
Pull requests with undescriptive or inaccurate titles *may* be closed or have their titles changed before merging.

Fill out the fields below.

All pull requests *must* pass CI to be merged. Check your pull request frequently for build failures until all checks pass.
Address build failures by pushing new commits or amending existing ones. Feel free to ask for help if you get stuck.
If a failure seems spurious (timeout or cache failure), you may push a new commit to re-run it.

After addressing review comments, re-request review to show that you are ready for your PR to be looked at again.

Pull requests which sit for a long time with broken CI or unaddressed review comments will be closed to clear the backlog.
If this happens, you are welcome to open a new pull request, but please be sure to address the feedback you have received previously.

Bug fixes should include a regression test which fails before the fix and passes afterwards. If this is infeasible, please explain why.

New features *should* include unit or integration tests in the appropriate folders. Database specific tests should go in `tests/<database>`.

Note that unsolicited pull requests implementing large or complex changes may not be reviwed right away.
Maintainer time and energy is limited and massive unsolicited pull requests require an outsized effort to review.

To make the best use of your time and ours, search for and participate in existing discussion on the issue tracker before opening a pull request.
The solution you came up with may have already been rejected or postponed due to other work needing to be done first,
or there may be a pending solution going down a different direction that you hadn't considered.

Pull requests that take existing discussion into account are the most likely to be merged.

Delete this block comment before submission to show that you have read and understand these instructions.
-->

### Does your PR solve an issue?
Delete this text and add "fixes #(issue number)".

Do *not* just list issue numbers here as they will not be automatically closed on merging this pull request unless prefixed with "fixes" or "closes".

### Is this a breaking change?
Delete this text and answer yes/no and explain.

If yes, this pull request will need to wait for the next major release (`0.{x + 1}.0`)

Behavior changes _can_ be breaking if significant enough.
Consider [Hyrum's Law](https://www.hyrumslaw.com/):

> With a sufficient number of users of an API,  
> it does not matter what you promise in the contract:  
> all observable behaviors of your system  
> will be depended on by somebody.
