### PR TITLE
test(mssql): pin read-only rows_affected semantics; document test connection limits

### DIFF
--- a/sqlx-mssql/MSSQL_SUPPORT.md
+++ b/sqlx-mssql/MSSQL_SUPPORT.md
@@ -1167,6 +1167,35 @@ The GitHub Actions workflow tests across:
 - **Async runtimes:** tokio, async-global-executor, smol
 - **TLS backends:** native-tls, rustls-aws-lc-rs, rustls-ring, none
 
+### Test Concurrency and Connection Limits
+
+Each `#[sqlx::test]` gets its own database and pool, but every test in the run shares the single SQL Server container's connection capacity. If many tests run in parallel and fail with `PoolTimedOut`, either limit the test runner's concurrency:
+
+```bash
+cargo test -- --test-threads 4
+```
+
+or shrink the per-test pool by using the `PoolOptions` test signature and building the pool explicitly:
+
+```rust
+use sqlx::{pool::PoolOptions, mssql::MssqlConnectOptions, Mssql};
+
+#[sqlx::test]
+async fn basic_test(
+    pool_options: PoolOptions<Mssql>,
+    connect_options: MssqlConnectOptions,
+) -> sqlx::Result<()> {
+    let pool = pool_options
+        .max_connections(1)
+        .connect_with(connect_options)
+        .await?;
+
+    sqlx::query("SELECT 1").execute(&pool).await?;
+
+    Ok(())
+}
+```
+
 ---
 
 ## Test Coverage

--- a/tests/mssql/mssql.rs
+++ b/tests/mssql/mssql.rs
@@ -170,6 +170,56 @@ async fn it_reports_rows_affected_for_dml() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Regression test: read-only statements must never report a previous DML
+// statement's affected-row count. SQL Server's DONE tokens are per-statement so
+// there is no stale-count hazard by construction, but this pins that contract —
+// the same one upstream fixed for SQLite, where `sqlite3_changes()` leaked the
+// prior DML's count into SELECT/BEGIN/COMMIT (launchbadge/sqlx#4306).
+#[sqlx_macros::test]
+async fn it_does_not_leak_dml_counts_into_read_only_statements() -> anyhow::Result<()> {
+    let mut conn = new::<Mssql>().await?;
+
+    conn.execute("CREATE TABLE #gadgets (id INTEGER PRIMARY KEY, label NVARCHAR(50) NULL);")
+        .await?;
+
+    for index in 1..=5_i32 {
+        sqlx::query("INSERT INTO #gadgets (id) VALUES (@p1)")
+            .bind(index)
+            .execute(&mut conn)
+            .await?;
+    }
+
+    // UPDATE hitting 3 rows establishes the count that must not leak below.
+    let done = sqlx::query("UPDATE #gadgets SET label = @p1 WHERE id >= @p2")
+        .bind("hit")
+        .bind(3_i32)
+        .execute(&mut conn)
+        .await?;
+    assert_eq!(done.rows_affected(), 3);
+
+    // A SELECT matching no rows reports 0, not the UPDATE's 3.
+    let done = sqlx::query("SELECT id FROM #gadgets WHERE id = @p1")
+        .bind(999_i32)
+        .execute(&mut conn)
+        .await?;
+    assert_eq!(done.rows_affected(), 0);
+
+    // A SELECT reports its own returned-row count (matching Postgres, which
+    // parses it from the `SELECT n` command tag), never the previous DML's.
+    let done = sqlx::query("SELECT id FROM #gadgets WHERE id = @p1")
+        .bind(1_i32)
+        .execute(&mut conn)
+        .await?;
+    assert_eq!(done.rows_affected(), 1);
+
+    // BEGIN/COMMIT on the no-parameter batch path report 0, mirroring the
+    // upstream SQLite assertion.
+    let done = conn.execute("BEGIN TRANSACTION; COMMIT;").await?;
+    assert_eq!(done.rows_affected(), 0);
+
+    Ok(())
+}
+
 #[sqlx_macros::test]
 async fn it_can_return_1000_rows() -> anyhow::Result<()> {
     let mut conn = new::<Mssql>().await?;


### PR DESCRIPTION
MSSQL follow-ups from the 0.9.0 upstream sync (PR #17), mirroring two upstream changes:

## Regression test for read-only `rows_affected` (upstream #4306 parity)
Upstream fixed SQLite leaking the previous DML statement's count into read-only statements and pinned the semantics with a test. The MSSQL driver has no such bug — DONE tokens are per-statement — but nothing pinned the contract. `it_does_not_leak_dml_counts_into_read_only_statements` in `tests/mssql/mssql.rs` now asserts:
- an UPDATE hitting 3 rows reports 3,
- a SELECT matching no rows reports 0 (not the stale 3),
- a SELECT reports its own returned-row count (Postgres-consistent),
- `BEGIN TRANSACTION; COMMIT;` on the no-parameter batch path reports 0.

## Test connection-limits docs (upstream #4278 parity)
New "Test Concurrency and Connection Limits" subsection under **Docker & CI** in `sqlx-mssql/MSSQL_SUPPORT.md`: parallel `#[sqlx::test]`s share the single container's connection capacity; remedies are `--test-threads` or the `PoolOptions<Mssql>` test signature (example adapted from the facade docs).

Also reviewed: upstream #4286's new `prepare-connection:` hook in `impl_database_ext!` needs no MSSQL override (defaults to no-op; `sp_describe_first_result_set` needs no session prep).

## Verification
- `cargo check`/`clippy -D warnings` on the `mssql` test target with the harness feature set — clean
- Targeted harness run: new test passes
- Full `tests/mssql/run-local.sh --no-fail-fast` — all green